### PR TITLE
`pytest` Install Path Fix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,8 +73,8 @@ jobs:
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
           git checkout ${{ inputs.config-tag }}
 
-          if [ -f "${{ env.BASE_EXPERIMENT_LOCATION }}/test/requirements.txt" ]; then
-            pip install -r ${{ env.BASE_EXPERIMENT_LOCATION }}/test/requirements.txt
+          if [ -f "${{ vars.REPRO_TEST_LOCATION }}/requirements.txt" ]; then
+            pip install -r ${{ vars.REPRO_TEST_LOCATION }}/requirements.txt
           fi
 
           # Run pytests - this also generates checksums files

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -80,8 +80,8 @@ jobs:
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
           git checkout ${{ inputs.config-branch-name }}
 
-          if [ -f "${{ env.BASE_EXPERIMENT_LOCATION }}/test/requirements.txt" ]; then
-            pip install -r ${{ env.BASE_EXPERIMENT_LOCATION }}/test/requirements.txt
+          if [ -f "${{ vars.REPRO_TEST_LOCATION }}/requirements.txt" ]; then
+            pip install -r ${{ vars.REPRO_TEST_LOCATION }}/requirements.txt
           fi
 
           # Run pytests - this also generates checksums files


### PR DESCRIPTION
In this PR:
* Updated search path for `test/requirements.txt` for `pip install`

Fixes 'pytest not found' bug as part of this run: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8000118562/job/21849013095#step:3:43