### PR TITLE
`pytest` exit code ignore on initial checksum creation

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -84,12 +84,15 @@ jobs:
             pip install -r ${{ vars.REPRO_TEST_LOCATION }}/requirements.txt
           fi
 
+          # In this case, we expect the pytest to fail because there are no checksums to compare
+          # against. But we still want the side-effect of creating the initial checksums.
+          set +e
+
           # Run pytests - this also generates checksums files
           pytest ${{ vars.REPRO_TEST_LOCATION }} -s \
             -m "checksum" \
             --rootdir ${{vars.REPRO_TEST_LOCATION }} \
             --output-path ${{ env.EXPERIMENT_LOCATION }}
-
 
           EOT
           echo "experiment-location=${{ env.EXPERIMENT_LOCATION }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In this PR:
* Disabled error reporting for initial pytest checksum checking

Fixes bug in https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8011878223/job/21889724893