### PR TITLE
Explicit `exit 0` after expected `pytest` error for Initial Checksum workflow

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -94,7 +94,11 @@ jobs:
             --rootdir ${{vars.REPRO_TEST_LOCATION }} \
             --output-path ${{ env.EXPERIMENT_LOCATION }}
 
+          # In this case, we want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
+          # after the expected `pytest` error.
+          exit 0
           EOT
+
           echo "experiment-location=${{ env.EXPERIMENT_LOCATION }}" >> $GITHUB_OUTPUT
           echo "::notice::Checksums generated on ${{ vars.DEPLOYMENT_TARGET }} at ${{ env.EXPERIMENT_LOCATION }}"
 


### PR DESCRIPTION
In this PR:
* Added explicit 'exit 0' after expected pytest error in ssh call

Fixes https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8011878223/job/21890228378