### PR TITLE
`commit-checksum-to-branch` job `if` conditional converted to `boolean`

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -17,7 +17,7 @@ on:
       committed-checksum-location:
         type: string
         required: false
-        default: ./testing/checksums
+        default: ./testing/checksum
         description: "If `commit-checksums`: Where in the repository the generated checksums should be committed to."
       committed-checksum-tag:
         type: string

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Move Checksums to Repo
         run: |
           mkdir -p ${{ inputs.committed-checksum-location }}
-          mv ${{ env.OUTPUT_LOCAL_LOCATION }}/* ${{ inputs.committed-checksum-location }}
+          mv ${{ env.OUTPUT_LOCAL_LOCATION }}/checksum/* ${{ inputs.committed-checksum-location }}
 
       - name: Commit Checksums to Repo
         run: |

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -123,7 +123,7 @@ jobs:
     name: Commit Checksum To ${{ inputs.config-branch-name }}
     needs:
       - generate-checksum
-    if: inputs.commit-checksums == 'true'
+    if: inputs.commit-checksums
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
In this PR:
* Converted commit-checksum-to-branch if conditional from string to bool

Fixes this bug here: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8011878223/job/21893170086 where the job was erroneously skipped