### PR TITLE
Added token that can force push to release branches

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -125,13 +125,12 @@ jobs:
       - generate-checksum
     if: inputs.commit-checksums
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.config-branch-name }}
           fetch-depth: 0
+          token: ${{ secrets.GH_FORCE_PUSH_TOKEN }}
 
       - name: Download Checksums
         uses: actions/download-artifact@v4


### PR DESCRIPTION
In this PR:
* Added token that can force push to release branches

Fixes bug in https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8015152252