### PR TITLE
Escape multiline `pytest` invocation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,7 @@ jobs:
   repro:
     # NOTE: A lot of these `vars` and `secrets` are not found in this repository. Instead, they are inherited
     # from the calling workflow (for example, `ACCESS-NRI/access-om2-configs`)
-    name: Run ${{ github.ref_name }}
+    name: Run ${{ inputs.config-tag }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment-name }}
     outputs:
@@ -84,7 +84,7 @@ jobs:
           # Run pytests - this also generates checksums files
           pytest ${{ vars.REPRO_TEST_LOCATION }} -s \
             -m "${{ inputs.test-markers }}" \
-            --rootdir ${{vars.REPRO_TEST_LOCATION }}
+            --rootdir ${{vars.REPRO_TEST_LOCATION }} \
             --output-path ${{ env.EXPERIMENT_LOCATION }} \
             --junitxml=${{ env.EXPERIMENT_LOCATION }}/checksum/test_report.xml
 


### PR DESCRIPTION
See failing Scheduled repro run: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8414918165/job/23039318450#step:3:110
This was failing because there was no associated `\` before the `--output-path`. 

This PR:
* Adds the `\` to the `pytest` command
* Updates the job name to be more meaningful