### PR TITLE
No initial `.version` fix

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -18,11 +18,11 @@ on:
         type: string
         required: false
         default: ./testing/checksum
-        description: "If `commit-checksums`: Where in the repository the generated checksums should be committed to."
+        description: "If checksums are committed: Where in the repository the generated checksums should be committed to."
       committed-checksum-tag:
         type: string
         required: false
-        description: "If `commit-checksums`: An optional tag to attach to the committed checksums."
+        description: "If checksums are committed: An optional tag to attach to the committed checksums."
       environment-name:
         type: string
         required: true

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Update version in metadata.yaml
         if: inputs.committed-checksum-tag != ''
-        run: yq -i '.version = ${{ inputs.committed-checksum-tag }}' metadata.yaml
+        run: yq -i '.version = "${{ inputs.committed-checksum-tag }}"' metadata.yaml
 
       - name: Commit Checksums to Repo
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -143,6 +143,10 @@ jobs:
           mkdir -p ${{ inputs.committed-checksum-location }}
           mv ${{ env.OUTPUT_LOCAL_LOCATION }}/checksum/* ${{ inputs.committed-checksum-location }}
 
+      - name: Update version in metadata.yaml
+        if: inputs.committed-checksum-tag != ''
+        run: yq -i '.version = ${{ inputs.committed-checksum-tag }}' metadata.yaml
+
       - name: Commit Checksums to Repo
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |


### PR DESCRIPTION
Related to the failures in this PR https://github.com/ACCESS-NRI/access-om2-configs/pull/66
In this PR:
* generate-initial-checksums.yml: Adds `.version` to metadata.yaml initially if `inputs.committed-checksum-tag` is set
* Cleaned up some language