### PR TITLE
Initial `.version` update to `metadata.yaml` fix

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -145,7 +145,10 @@ jobs:
 
       - name: Update version in metadata.yaml
         if: inputs.committed-checksum-tag != ''
-        run: yq -i '.version = "${{ inputs.committed-checksum-tag }}"' metadata.yaml
+        run: |
+          full_tag=${{ inputs.committed-checksum-tag }}
+          version=${full_tag/*-}
+          yq -i '.version = "${version}"' metadata.yaml
 
       - name: Commit Checksums to Repo
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -153,8 +153,8 @@ jobs:
       - name: Commit Checksums to Repo
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
           git add .
           git commit -m "Added initial checksums generated from ${{ inputs.config-branch-name }}"
           git push


### PR DESCRIPTION
See `metadata.yaml` on the `release-*` branch here: https://github.com/ACCESS-NRI/access-om2-configs/blob/release-1deg_jra55_ryf_bgc-2.0/metadata.yaml#L28 - it should not have the cruft at the front, just the version. 

In this PR: 
* `generate-initial-checksum.yml`: cut the full inputs.committed-checksum-tag into just the version