### PR TITLE
Explicitly specify the version of the `pytest` tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,11 @@ on:
         type: string
         required: true
         description: A python expression of markers to pass to the reproducibility pytests
+      test-version:
+        type: string
+        required: false
+        default: main
+        description: commit, branch or tag containing a particular version of the pytest tests
     outputs:
       artifact-name:
         value: ${{ jobs.repro.outputs.artifact-name }}
@@ -62,6 +67,7 @@ jobs:
 
           # Update test directory
           git -C ${{ vars.REPRO_TEST_LOCATION }} pull
+          git -C ${{ vars.REPRO_TEST_LOCATION }} checkout ${{ inputs.test-version }} --force
 
           # Remove base experiment if it already exists
           if [ -d "${{ env.BASE_EXPERIMENT_LOCATION }}" ]; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,8 +66,9 @@ jobs:
           module load payu/${{ vars.PAYU_VERSION }}
 
           # Update test directory
-          git -C ${{ vars.REPRO_TEST_LOCATION }} pull
+          git -C ${{ vars.REPRO_TEST_LOCATION }} fetch
           git -C ${{ vars.REPRO_TEST_LOCATION }} checkout ${{ inputs.test-version }} --force
+          git -C ${{ vars.REPRO_TEST_LOCATION }} pull
 
           # Remove base experiment if it already exists
           if [ -d "${{ env.BASE_EXPERIMENT_LOCATION }}" ]; then

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This workflow is a generic reusable workflow that runs reproducibility checks in
 | `config-tag` | `string` | A tag on an associated config branch to use for the reproducibility run | `true` | N/A | `"release-1deg_jra55_iaf-1.2"` |
 | `environment-name` | `string` | The name of a GitHub Deployment Environment that is inherited from the caller | `true` | N/A | `"Gadi"` |
 | `test-markers` | `string` (python-style expression) | A python expression of markers to pass to the reproducibility pytests `-m` flag. These pytests are defined in the caller | `true` | N/A | `"checksums and fast and not performance"` |
+| `test-version` | `string` | commit, branch or tag containing a particular version of the pytest tests | `false` | `"main"` | `"uyg234j3"` |
 
 #### Outputs
 


### PR DESCRIPTION
In this PR:
* Added an input that specifies the version of the pytest tests. This will be defaulting to the existing functionality of the pytests on `main`.

References ACCESS-NRI/access-om2-configs#61