### PR TITLE
Use a virtual environment to isolate install and run model-config-tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,14 @@ on:
         type: string
         required: true
         description: A python expression of markers to pass to the reproducibility pytests
+      model-config-tests-version:
+        type: string
+        required: true
+        description: A version of the model-config-tests package
+      python-version:
+        type: string
+        required: true
+        description: The python module version used to create test virtual environment
     outputs:
       artifact-name:
         value: ${{ jobs.repro.outputs.artifact-name }}
@@ -53,15 +61,9 @@ jobs:
         id: run
         env:
           BASE_EXPERIMENT_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/base-experiment
+          TEST_VENV_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/test-venv
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
-
-          # Load payu conda enviroment
-          module use ${{ vars.PAYU_MODULE_LOCATION }}
-          module load payu/${{ vars.PAYU_VERSION }}
-
-          # Update test directory
-          git -C ${{ vars.REPRO_TEST_LOCATION }} pull
 
           # Remove base experiment if it already exists
           if [ -d "${{ env.BASE_EXPERIMENT_LOCATION }}" ]; then
@@ -73,24 +75,33 @@ jobs:
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
           git checkout ${{ inputs.config-tag }}
 
-          if [ -f "${{ vars.REPRO_TEST_LOCATION }}/requirements.txt" ]; then
-            pip install -r ${{ vars.REPRO_TEST_LOCATION }}/requirements.txt
-          fi
+          # Load Python module
+          module load python3/${{ inputs.python-version }}
 
-          # The pytest might fail in this command, but that is okay. We still want to run the
-          # rest of the commands after this step.
+          # Create and activate virtual environment
+          python3 -m venv ${{ env.TEST_VENV_LOCATION }}
+          source ${{ env.TEST_VENV_LOCATION }}/bin/activate
+
+          # Install model-config-tests
+          pip install model-config-tests==${{ inputs.model-config-tests-version }}
+
+          # The pytests in model-config-tests might fail in this command,
+          # but that is okay. We still want to run the rest of the commands
+          # after this step.
           set +e
 
-          # Run pytests - this also generates checksums files
-          pytest ${{ vars.REPRO_TEST_LOCATION }} -s \
-            -m "${{ inputs.test-markers }}" \
-            --rootdir ${{vars.REPRO_TEST_LOCATION }} \
+          # Run model-config-tests pytests - this also generates checksums files
+          model-config-tests -s -m "${{ inputs.test-markers }}" \
             --output-path ${{ env.EXPERIMENT_LOCATION }} \
             --junitxml=${{ env.EXPERIMENT_LOCATION }}/checksum/test_report.xml
+          
+          # Deactivate and remove the test virtual environment
+          deactivate
+          rm -rf ${{ env.TEST_VENV_LOCATION }}
 
-            # We want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
-            # after a potential `pytest` error.
-            exit 0
+          # We want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
+          # after a potential `pytest` error.
+          exit 0          
           EOT
           echo "experiment-location=${{ env.EXPERIMENT_LOCATION }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -27,6 +27,14 @@ on:
         type: string
         required: true
         description: The name of a GitHub Environment that is inherited from the caller.
+      model-config-tests-version:
+        type: string
+        required: true
+        description: A version of the model-config-tests package
+      python-version:
+        type: string
+        required: true
+        description: The python module version used to create test virtual environment
     outputs:
       checksum-location:
         value: ${{ jobs.generate-checksum.outputs.checksum-location }}
@@ -60,15 +68,9 @@ jobs:
         id: run
         env:
           BASE_EXPERIMENT_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/base-experiment
+          TEST_VENV_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/test-venv
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<EOT
-
-          # Load payu conda enviroment
-          module use ${{ vars.PAYU_MODULE_LOCATION }}
-          module load payu/${{ vars.PAYU_VERSION }}
-
-          # Update test directory
-          git -C ${{ vars.REPRO_TEST_LOCATION }} pull
 
           # Remove base experiment if it already exists
           if [ -d "${{ env.BASE_EXPERIMENT_LOCATION }}" ]; then
@@ -80,19 +82,29 @@ jobs:
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
           git checkout ${{ inputs.config-branch-name }}
 
-          if [ -f "${{ vars.REPRO_TEST_LOCATION }}/requirements.txt" ]; then
-            pip install -r ${{ vars.REPRO_TEST_LOCATION }}/requirements.txt
-          fi
+           # Load Python module
+          module load python3/${{ inputs.python-version }}
 
-          # In this case, we expect the pytest to fail because there are no checksums to compare
+          # Create and activate virtual environment
+          python3 -m venv ${{ env.TEST_VENV_LOCATION }}
+          source ${{ env.TEST_VENV_LOCATION }}/bin/activate
+
+          # Install model-config-tests
+          pip install model-config-tests==${{ inputs.model-config-tests-version }}
+
+          # In this case, we expect the pytests in model-config-tests
+          # to fail because there are no checksums to compare
           # against. But we still want the side-effect of creating the initial checksums.
           set +e
 
           # Run pytests - this also generates checksums files
-          pytest ${{ vars.REPRO_TEST_LOCATION }} -s \
+          model-config-tests -s \
             -m "checksum" \
-            --rootdir ${{vars.REPRO_TEST_LOCATION }} \
             --output-path ${{ env.EXPERIMENT_LOCATION }}
+
+          # Deactivate and remove the test virtual environment
+          deactivate
+          rm -rf ${{ env.TEST_VENV_LOCATION }}
 
           # In this case, we want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
           # after the expected `pytest` error.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ call-reusable:
 ### Reproducibility CI Checks: `checks.yml`
 
 This workflow is a generic reusable workflow that runs reproducibility checks in a given deployment environment.
-
 > [!NOTE]
 > The `vars` and `secrets` within this workflow are inherited from the caller, NOT defined in this repository. Therefore, they must be defined by any workflow that calls this workflow, and any call to this workflow must have `secrets: inherit`.
 
@@ -33,7 +32,9 @@ This workflow is a generic reusable workflow that runs reproducibility checks in
 | `model-name` | `string` | The name of the model to check for reproducibility | `true` | N/A | `"access-om2"` |
 | `config-tag` | `string` | A tag on an associated config branch to use for the reproducibility run | `true` | N/A | `"release-1deg_jra55_iaf-1.2"` |
 | `environment-name` | `string` | The name of a GitHub Deployment Environment that is inherited from the caller | `true` | N/A | `"Gadi"` |
-| `test-markers` | `string` (python-style expression) | A python expression of markers to pass to the reproducibility pytests `-m` flag. These pytests are defined in the caller | `true` | N/A | `"checksums and fast and not performance"` |
+| `test-markers` | `string` (python-style expression) | A python expression of markers to pass to the pytests `-m` flag. These are defined in `model-config-tests` | `true` | N/A | `"checksums"` |
+| `model-config-tests-version` | `string` | A version of `model-config-tests` package | `true` | N/A | `"0.0.1"` |
+| `python-version` | `string` | The version of the python module to load. This is used to create the virtual test environment | `true` | N/A | `"3.11.0"` |
 
 #### Outputs
 
@@ -56,6 +57,8 @@ jobs:
       environment-name: Gadi
       config-tag: ${{ github.ref_name }}
       test-markers: checksum
+      model-config-tests-version: "0.0.1"
+      python-version: "3.11.0"
     secrets: inherit
 ```
 
@@ -79,6 +82,8 @@ This workflow is used to create the initial checksums for a given config branch,
 | `committed-checksum-location` | `string` | Where in the repository the generated checksums should be committed to | Only if `commit-checksums` is `true` | `"./testing/checksums"` | `"./custom/checksum/location"` |
 | `committed-checksum-tag` | `string` | An optional tag to attach to the committed checksums | Only if `commit-checksums` is `true` | `""` | `release-1deg_jra55_iaf-1.0` |
 | `environment-name` | `string` | The name of a GitHub Environment that is inherited from the caller | `true` | N/A | `"Gadi Initial Checksum"` |
+| `model-config-tests-version` | `string` | A version of model-config-tests package | `true` | N/A | `"0.0.1"` |
+| `python-version` | `string` | The version of the python module to load. This is used to create the virtual test environment | `true` | N/A | `"3.11.0"` |
 
 #### Outputs
 
@@ -100,6 +105,8 @@ jobs:
       config-branch-name: release-1deg_jra55_iaf
       commit-checksums: false
       environment-name: "Gadi Initial Checksum"
+      model-config-tests-version: "0.0.1"
+      python-version: "3.11.0"
     secrets: inherit
 
   gen-checksums-with-commit:
@@ -112,6 +119,8 @@ jobs:
       committed-checksum-location: ./checksums
       committed-checksum-tag: release-1deg_jra55_iaf-1.0
       environment-name: "Gadi Initial Checksum"
+      model-config-tests-version: "0.0.1"
+      python-version: "3.11.0"
     permissions:
       contents: write
     secrets: inherit


### PR DESCRIPTION
Create/teardown an virtual environment which installs and runs the model-config-tests.

Requires: PR in `access-om2-config`, that pass `model-config-tests-version` and `python-version` as inputs (see https://github.com/ACCESS-NRI/access-om2-configs/pull/111)

Closes #27 